### PR TITLE
Do not store raw password on blockchain

### DIFF
--- a/Log In Authentication.sol
+++ b/Log In Authentication.sol
@@ -2,29 +2,28 @@ pragma solidity >=0.7.0 <0.9.0;
 //SPDX-License-Identifier: MIT
 
 contract LoginAuthentication {
+    // storing hash of password against user instead of raw password
+    mapping(string => bytes32) passwordHashOf;
 
-    string private username= "taeba";   //declaring state variables
-    string private password = "HELLO";
-    string newusername;
-    string newpassword;
-
-function USERNAME(string memory a) public {  //getting username from the user
-    newusername = a;
-}
-function PASSWORD(string memory b) public { //getting password from the user
-    newpassword = b;
-}
-function LOGIN() view public returns (string memory)
-    {
-        if (
-            keccak256(abi.encodePacked(username)) == keccak256(abi.encodePacked(newusername)) && 
-            keccak256(abi.encodePacked(password)) == keccak256(abi.encodePacked(newpassword))
-        ) {
-            return "Successfully LogIn";
-        }
-        else{
-        return "Wrong credentials Plz Try Again";
-        }
+    function addUser(string memory username, string memory password)public{
+        require(
+            passwordHashOf[username] == bytes32(0), // password hash should be unset
+            "User is already added"
+        );
+        passwordHashOf[username] = keccak256(abi.encodePacked(password));
     }
 
+    // return true if User entered the right password
+    function login(string memory username, string memory password)view public returns(bool){
+        return keccak256(abi.encodePacked(password)) == passwordHashOf[username];
+    }
+
+    function changePassword(
+        string memory username,
+        string memory oldPassword,
+        string memory newPassword
+    ) public {
+        require(login(username, oldPassword), "Invalid Password!");
+        passwordHashOf[username] = keccak256(abi.encodePacked(newPassword));
+    }
 }


### PR DESCRIPTION
make smart contracts more robust.
Avoid storing passwords on the blockchain. Even private variables can be read using external tools. This is done by accessing their corresponding memory location in the contract storage.
The best practice is to store the hash of the password.

Review your concepts on hashing, there is no reason for hashing both input for comparing:
`keccak256(abi.encodePacked(password)) == keccak256(abi.encodePacked(newPassword))`
is the same as
`password == newPassword`
This way you are not using the actual Power of hashing function